### PR TITLE
add: 회원가입 로직 변경(사용자명 받도록 수정)

### DIFF
--- a/apigateway-service/src/main/java/com/epicode/apigatewayservice/filter/JwtAuthenticationFilter.java
+++ b/apigateway-service/src/main/java/com/epicode/apigatewayservice/filter/JwtAuthenticationFilter.java
@@ -100,8 +100,8 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory<JwtAut
         response.setStatusCode(httpStatus);
         response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
-        // JSON 에러 메시지 생성
-        String errorMessage = String.format("{\"error\": \"%s\"}", error);
+        // JSON 에러 메시지 생성 (상태코드와 메시지 포함)
+        String errorMessage = String.format("{\"status\": %d, \"error\": \"%s\"}", httpStatus.value(), error);
         byte[] bytes = errorMessage.getBytes(StandardCharsets.UTF_8);
         DataBuffer buffer = response.bufferFactory().wrap(bytes);
 
@@ -112,4 +112,5 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory<JwtAut
                     return Mono.empty();
                 }));
     }
+
 }

--- a/user-service/src/main/java/com/epicode/controller/AuthController.java
+++ b/user-service/src/main/java/com/epicode/controller/AuthController.java
@@ -58,10 +58,8 @@ public class AuthController {
         try {
             // KakaoService를 통해 JWT 토큰 발급
             String jwtToken = kakaoService.authenticateWithKakao(code);
-
             // JWT 토큰 반환
             return ResponseEntity.ok(jwtToken);
-
         } catch (IllegalStateException e) {
             log.error("카카오 인증 실패 - 상태 오류: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("카카오 인증 실패: " + e.getMessage());
@@ -72,6 +70,13 @@ public class AuthController {
             log.error("예상치 못한 오류 발생: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("알 수 없는 오류: " + e.getMessage());
         }
+    }
+
+    @GetMapping("/join")
+    public ResponseEntity<?> joinUser(@RequestHeader("X-Authenticated-User") String email,
+                                         @RequestParam String name) {
+        kakaoService.saveUser(email,name);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 //
 //    @GetMapping("/info")

--- a/user-service/src/main/java/com/epicode/exception/ErrorCode.java
+++ b/user-service/src/main/java/com/epicode/exception/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
     SALARY_NOT_FOUND(HttpStatus.UNAUTHORIZED, "해당 브랜치에서 유저 급여 정보를 찾을 수 없습니다."),
     SPECIFIC_SALARY_NOT_FOUND(HttpStatus.UNAUTHORIZED, "해당 특별 급여 정보를 찾을 수 없습니다."),
     USER_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "사용자가 인증되지 않았습니다."),
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 문제가 발생했습니다.");
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 문제가 발생했습니다."),
+    TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "토큰을 확인할 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입 된 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "가입되지 않은 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/user-service/src/main/java/com/epicode/security/JwtUtil.java
+++ b/user-service/src/main/java/com/epicode/security/JwtUtil.java
@@ -17,7 +17,6 @@ public class JwtUtil {
     private final Key SECRET_KEY;
     private static final long EXPIRATION_TIME = 86400000; // 24 hours
 
-
     public JwtUtil(@Value("${jwt.secret-key}") String secretKey) {
         byte[] decodedKey = Base64.getDecoder().decode(secretKey);
         this.SECRET_KEY = Keys.hmacShaKeyFor(decodedKey);
@@ -47,8 +46,8 @@ public class JwtUtil {
 //                .setSigningKey(SECRET_KEY)
 //                .build()
 //                .parseClaimsJws(token)
-//                .getBody(); // Claims에서 userId 추출
-//        return claims.get("userId", Long.class); // userId를 Long 타입으로 반환
+//                .getBody();
+//        return claims.get("userId", Long.class);
 //    }
 //
 //    public Long[] getBranchIdsFromToken(String token) {

--- a/user-service/src/main/java/com/epicode/service/KakaoService.java
+++ b/user-service/src/main/java/com/epicode/service/KakaoService.java
@@ -1,5 +1,7 @@
 package com.epicode.service;
 import com.epicode.domain.User;
+import com.epicode.exception.CustomException;
+import com.epicode.exception.ErrorCode;
 import com.epicode.repository.UserBranchRepository;
 import com.epicode.repository.UserRepository;
 import com.epicode.security.JwtUtil;
@@ -30,16 +32,16 @@ public class KakaoService {
         try {
             String accessToken = getAccessTokenFromKakao(code);
             if (accessToken == null || accessToken.isEmpty()) {
-                throw new IllegalStateException("토큰이 비어있습니다.");
+                throw new CustomException(ErrorCode.TOKEN_ERROR);
             }
 
             String userEmail = getUserInfoFromKakao(accessToken);
             if (userEmail == null || userEmail.isEmpty()) {
-                throw new IllegalStateException("유저 정보가 비어있습니다.");
+                throw new CustomException(ErrorCode.USER_NOT_AUTHORIZED);
             }
 
             if (!userRepository.existsByEmail(userEmail)) {
-                saveNewUser(userEmail); // 사용자 정보 저장
+
             }
 
             Long userId = userRepository.findByEmail(userEmail).getId();
@@ -51,12 +53,15 @@ public class KakaoService {
         }
     }
 
-    private void saveNewUser(String email) {
-        User user = new User();
-        user.setEmail(email);
-        user.setName("김크루");//임시 지정
-        System.out.println(user);
-        userRepository.save(user);
+     public void saveUser(String email,String name) {
+         User user = new User();
+         user.setEmail(email);
+         user.setName(name);
+         //System.out.println(user);
+         if(userRepository.existsByEmail(email)){
+             throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
+         }
+         userRepository.save(user);
     }
     public void redirectToKakao(HttpServletResponse response) {
         try {
@@ -130,4 +135,5 @@ public class KakaoService {
             throw new RuntimeException("카카오 유저 정보 요청 중 오류: " + e.getMessage());
         }
     }
+
 }


### PR DESCRIPTION
- 기존 로직: 카카오 로그인(인증) 후, DB없으면 바로 가입(사용자명 from 카카오)
- 이슈 발생: 사업자번호가 없어 사용자명 접근 불가 -> 별도로 입력받는 로직 추가(사용자명 from 입력값)
- 변경된 로직: 인증 -> 입력값 전달받기(**new api추가: api/auth/join?name=**) -> 가입 
- 유의 사항: 이름까지 입력 후 가입 완료하고 branch는 그 다음 로직임!
