### PR TITLE
fix: Branch list리턴 값 (id,name) 수정

### DIFF
--- a/branch-service/src/main/java/com/epicode/controller/BranchController.java
+++ b/branch-service/src/main/java/com/epicode/controller/BranchController.java
@@ -1,5 +1,6 @@
 package com.epicode.controller;
 
+import com.epicode.dto.BranchIdNameProjection;
 import com.epicode.dto.WorkerProjection;
 import com.epicode.exception.CustomException;
 import com.epicode.exception.ErrorCode;
@@ -48,29 +49,36 @@ public class BranchController {
                     @Parameter(name = "Authorization", description = "JWT Bearer 토큰", required = true, example = "Bearer eyJhbGciOiJI...")
             }
     )
-    public List<String> getBranchNames(
+    public List<BranchIdNameProjection> getBranchNames(
             @RequestHeader("X-Authenticated-User-Id") String userId
     ) {
         // 사용자의 Branch 정보를 가져오기
-        List<String> branchNames = branchService.getBranchNamesByUserId(Long.valueOf(userId));
+        List<BranchIdNameProjection> branchNames = branchService.getBranchesByUserId(Long.valueOf(userId));
         return branchNames != null ? branchNames : List.of();
-//        // 사용자 검증
-//        User user = userRepository.findIdByEmail(email);
-//        List<String> branchNames = new ArrayList<>();
-//        if (user == null) {
-//            throw new IllegalArgumentException("해당하는 사용자가 없습니다.");
-//        } else {
-//            Long[] branchIds = Arrays.stream(branches.split(","))
-//                    .map(Long::valueOf)
-//                    .toArray(Long[]::new);
-//            branchNames = branchService.getBranchNamesByUserIds(branchIds);
-//            if (branchNames == null || branchNames.isEmpty()) {
-//                //throw new NoBranchFoundException("가입된 지점이 없습니다.");
-//                return new ArrayList<>();
-//            }
-//        }
-//        return branchNames;
     }
+//    public List<String> getBranchNames(
+//            @RequestHeader("X-Authenticated-User-Id") String userId
+//    ) {
+//        // 사용자의 Branch 정보를 가져오기
+//        List<String> branchNames = branchService.getBranchNamesByUserId(Long.valueOf(userId));
+//        return branchNames != null ? branchNames : List.of();
+////        // 사용자 검증
+////        User user = userRepository.findIdByEmail(email);
+////        List<String> branchNames = new ArrayList<>();
+////        if (user == null) {
+////            throw new IllegalArgumentException("해당하는 사용자가 없습니다.");
+////        } else {
+////            Long[] branchIds = Arrays.stream(branches.split(","))
+////                    .map(Long::valueOf)
+////                    .toArray(Long[]::new);
+////            branchNames = branchService.getBranchNamesByUserIds(branchIds);
+////            if (branchNames == null || branchNames.isEmpty()) {
+////                //throw new NoBranchFoundException("가입된 지점이 없습니다.");
+////                return new ArrayList<>();
+////            }
+////        }
+////        return branchNames;
+//    }
 
     @GetMapping({"/search/{branchName}"})
     @Operation(

--- a/branch-service/src/main/java/com/epicode/dto/BranchIdNameProjection.java
+++ b/branch-service/src/main/java/com/epicode/dto/BranchIdNameProjection.java
@@ -1,0 +1,6 @@
+package com.epicode.dto;
+
+public interface BranchIdNameProjection {
+    Long getId();
+    String getName();
+}

--- a/branch-service/src/main/java/com/epicode/repository/UserBranchRepository.java
+++ b/branch-service/src/main/java/com/epicode/repository/UserBranchRepository.java
@@ -1,5 +1,6 @@
 package com.epicode.repository;
 
+import com.epicode.dto.BranchIdNameProjection;
 import com.epicode.dto.WorkerProjection;
 import com.epicode.model.User;
 import com.epicode.model.UserBranch;
@@ -12,8 +13,8 @@ import java.util.List;
 
 @Repository
 public interface UserBranchRepository extends JpaRepository<UserBranch, Long> {
-    @Query("SELECT ub.branch.id FROM UserBranch ub WHERE ub.user.id = :userId")
-    List<Long> findBranchIdsByUserId(@Param("userId") Long userId);
+    @Query("SELECT b.id AS id, b.name AS name FROM Branch b WHERE b.id IN (SELECT ub.branch.id FROM UserBranch ub WHERE ub.user.id = :userId)")
+    List<BranchIdNameProjection> findBranchIdsAndNamesByUserId(Long userId);
 //    @Query("SELECT b.name FROM Branch b WHERE b.id IN :branchIds")
 //    List<String> findBranchNamesByIds(@Param("branchIds") List<Long> branchIds);
     @Query("SELECT u.id AS id, u.name AS name " +

--- a/branch-service/src/main/java/com/epicode/service/BranchService.java
+++ b/branch-service/src/main/java/com/epicode/service/BranchService.java
@@ -1,4 +1,5 @@
 package com.epicode.service;
+import com.epicode.dto.BranchIdNameProjection;
 import com.epicode.dto.WorkerProjection;
 import com.epicode.model.Branch;
 import com.epicode.model.UserBranch;
@@ -6,10 +7,11 @@ import com.epicode.model.UserBranch;
 import java.util.List;
 
 public interface BranchService {
-    List<String> getBranchNamesByUserId(Long userId);
-    List<String> getBranchNamesByUserIds(Long[] branchIds);
+    //List<String> getBranchNamesByUserId(Long userId);//브랜치 네임 가져오기(ver1)
+    //List<String> getBranchNamesByUserIds(Long[] branchIds);
     Long getBranchIdByName(String name);
     void createBranch(Branch branch, Long userId, String email);
     List<WorkerProjection> getWorkersByBranchId(Long branchId);
     Branch getBranchProfile(Long branchId);
+    List<BranchIdNameProjection> getBranchesByUserId(Long userId);//브랜치id,name 가져오기(ver2)
 }

--- a/branch-service/src/main/java/com/epicode/service/BranchServiceImpl.java
+++ b/branch-service/src/main/java/com/epicode/service/BranchServiceImpl.java
@@ -1,4 +1,5 @@
 package com.epicode.service;
+import com.epicode.dto.BranchIdNameProjection;
 import com.epicode.dto.WorkerProjection;
 import com.epicode.exception.CustomException;
 import com.epicode.exception.ErrorCode;
@@ -24,21 +25,26 @@ public class BranchServiceImpl implements BranchService {
 
 
     // userId 기반 branchName 조회
+//    @Override
+//    public List<String> getBranchNamesByUserId(Long userId) {
+//        System.out.println(userId + "유저의 브랜치를 불러옵니다!");
+//        //UserBranch에서 branchId 목록 조회
+//        List<Long> branchIds = userBranchRepository.findBranchIdsByUserId(userId);
+//        //Branch에서 branchName 목록 조회
+//        System.out.println(branchRepository.findBranchNamesByIds(branchIds));
+//        return branchRepository.findBranchNamesByIds(branchIds);
+//    }
     @Override
-    public List<String> getBranchNamesByUserId(Long userId) {
-        System.out.println(userId + "유저의 브랜치를 불러옵니다!");
-        //UserBranch에서 branchId 목록 조회
-        List<Long> branchIds = userBranchRepository.findBranchIdsByUserId(userId);
-        //Branch에서 branchName 목록 조회
-        System.out.println(branchRepository.findBranchNamesByIds(branchIds));
-        return branchRepository.findBranchNamesByIds(branchIds);
+    public List<BranchIdNameProjection> getBranchesByUserId(Long userId) {
+        return userBranchRepository.findBranchIdsAndNamesByUserId(userId);
     }
-    //branchIds기반 branchName 조회
-    @Override
-    public List<String> getBranchNamesByUserIds(Long[] branchIds) {
-        //branchIds -> branchName 목록 조회
-        return branchRepository.findBranchNamesByIds(List.of(branchIds));
-    }
+//
+//    //branchIds기반 branchName 조회
+//    @Override
+//    public List<String> getBranchNamesByUserIds(Long[] branchIds) {
+//        //branchIds -> branchName 목록 조회
+//        return branchRepository.findBranchNamesByIds(List.of(branchIds));
+//    }
     // branchName 기반 branchId 조회
     @Override
     public Long getBranchIdByName(String name) {

--- a/manual-service/src/main/java/com/epicode/manualservice/service/ManualService.java
+++ b/manual-service/src/main/java/com/epicode/manualservice/service/ManualService.java
@@ -32,7 +32,7 @@ public class ManualService {
 
     public void validateBranchAccess(String jwtToken,Integer branchId) {
         List<String> branchIdList = getBranchesForUser(jwtToken);
-        //System.out.println(branchIdList);
+        System.out.println(branchIdList);
         if (!branchIdList.contains(String.valueOf(branchId))) {
             throw new CustomException(ErrorCode.USER_BRANCH_NOT_EXISTS);//404
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8cfbb2a6-3cdc-4a10-8e49-69e3c95117bb)

- api/branch/list 조회 시, 위와 같이 리턴 값 변경
- 이에 따라 기존의 search/{branchName} api는 사용하지 않아도 됨(id값 알아낼 필요 없음)